### PR TITLE
fix cmake execute_process working directory issue

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -44,7 +44,8 @@ endif ()
 # get last commit id
 MACRO(GET_LAST_COMMIT_ID LAST_COMMIT_ID)
     execute_process(COMMAND sh "-c" "git log --decorate | head -n 1 | awk '{print $2}'"
-            OUTPUT_VARIABLE ${LAST_COMMIT_ID})
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE ${LAST_COMMIT_ID})
 ENDMACRO(GET_LAST_COMMIT_ID)
 
 GET_LAST_COMMIT_ID(LAST_COMMIT_ID)


### PR DESCRIPTION
Fix working directory issue in execute_process of get repo commit id action. By the way, user can run cmake command outside the arctern repo directory.

Reference: https://cmake.org/cmake/help/v3.12/command/execute_process.html.