### PR TITLE
add verbose argument to arctern.version

### DIFF
--- a/cpp/src/gis/gis_functions.cpp
+++ b/cpp/src/gis/gis_functions.cpp
@@ -344,7 +344,7 @@ std::shared_ptr<arrow::Array> ST_Envelope_Aggr(
 /*************************** AGGREGATE FUNCTIONS ***************************/
 
 std::string GIS_Version() {
-  const std::string info = "gis version : " + std::string(LIB_VERSION) + "\n" +
+  const std::string info = "version : " + std::string(LIB_VERSION) + "\n" +
 #ifdef USE_GPU
                            "build type : " + CMAKE_BUILD_TYPE + "/GPU \n" +
 #else

--- a/python/arctern/_wrapper_func.py
+++ b/python/arctern/_wrapper_func.py
@@ -1533,8 +1533,12 @@ def fishnet_map_layer(vega, points, weights, transform=True):
     rs = arctern_core_.fishnet_map(vega_string, geos_rs, weights_rs)
     return base64.b64encode(rs.buffers()[1].to_pybytes())
 
-def version():
+def version(verbose=False):
     """
     :return: version of arctern
     """
-    return arctern_core_.GIS_Version().decode("utf-8")
+    full_version_info = arctern_core_.GIS_Version().decode("utf-8")
+    if verbose:
+        return full_version_info
+    only_versin_info = full_version_info.split("\n")[0]
+    return only_versin_info

--- a/python/arctern/_wrapper_func.py
+++ b/python/arctern/_wrapper_func.py
@@ -1535,7 +1535,13 @@ def fishnet_map_layer(vega, points, weights, transform=True):
 
 def version(verbose=False):
     """
-    :return: version of arctern
+    Return the information of arctern version.
+
+    :type verbose: bool
+    :param verbose: whether to get other information besides version
+
+    :rtype: bool
+    :return: Information of arctern version.
     """
     full_version_info = arctern_core_.GIS_Version().decode("utf-8")
     if verbose:

--- a/python/arctern/_wrapper_func.py
+++ b/python/arctern/_wrapper_func.py
@@ -1540,7 +1540,7 @@ def version(verbose=False):
     :type verbose: bool
     :param verbose: whether to get other information besides version
 
-    :rtype: bool
+    :rtype: str
     :return: Information of arctern version.
     """
     full_version_info = arctern_core_.GIS_Version().decode("utf-8")

--- a/spark/pyspark/arctern_pyspark/__init__.py
+++ b/spark/pyspark/arctern_pyspark/__init__.py
@@ -17,9 +17,15 @@ from .render_func import *
 from .gis_func import *
 from .plot import plot
 
-def version():
+def version(verbose=False):
     """
-    :return: version of arctern_pyspark
+    Return the information of arctern_pyspark version.
+
+    :type verbose: bool
+    :param verbose: whether to get other information besides version
+
+    :rtype: str
+    :return: Information of arctern_pyspark version.
     """
     import arctern
-    return arctern.version()
+    return arctern.version(verbose)


### PR DESCRIPTION
fix [pr 638](https://github.com/zilliztech/arctern/issues/638)

example:

```python
>>> import arctern
>>> arctern.version()
'version : 0.2.0'
>>> arctern.version(True)
'version : 0.2.0\nbuild type : Release/CPU \nbuild time : 2020-05-25 17:05.14\ncommit id : c091d29b2e663cdb289db3ea98dd09b008ed2727\n'
>>> print(arctern.version(True))
version : 0.2.0
build type : Release/CPU 
build time : 2020-05-25 17:05.14
commit id : c091d29b2e663cdb289db3ea98dd09b008ed2727
```